### PR TITLE
Use env to locate bash.

### DIFF
--- a/priv/autoextract.sh
+++ b/priv/autoextract.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ThisFile="$(which $0)"
 

--- a/priv/build_tar.sh
+++ b/priv/build_tar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SOURCEDIR=$(dirname "${BASH_SOURCE[0]}")
 
 build_tar() {


### PR DESCRIPTION
For OSes where bash isn't in /usr/bin.

This was already the case for priv/vir, just not the support scripts.